### PR TITLE
Fixed bug (#2) when reading some initial values

### DIFF
--- a/BlueEyes.TestApp/BlueEyes.TestApp.csproj
+++ b/BlueEyes.TestApp/BlueEyes.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlueEyes.Tests/BlueEyes.Tests.csproj
+++ b/BlueEyes.Tests/BlueEyes.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlueEyes.Tests/ReadWriteTimeseriesTests.cs
+++ b/BlueEyes.Tests/ReadWriteTimeseriesTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace BlueEyes.Tests
+{
+    public class ReadWriteTimeseriesTests
+    {
+        [Fact]
+        public void WrittenValuesCanBeReadBackCorrectly()
+        {
+            var values = new (DateTime, double)[]
+            {
+                (new DateTime(2019, 06, 03, 0, 0, 0, DateTimeKind.Utc), 1154.84765552935)
+            };
+
+            var timeSeries = new TimeSeries();
+
+            foreach (var (timestamp, value) in values)
+            {
+                timeSeries.AddPoint(timestamp, value);
+            }
+
+            var buffer = timeSeries.ToArray();
+
+            var reader = new TimeSeries(buffer);
+            var actual = new List<(DateTime, double)>();
+
+            while (reader.HasMorePoints)
+            {
+                actual.Add(reader.ReadNext());
+            }
+
+            actual.Count.Should().Be(values.Length);
+
+            for (int i = 0; i < actual.Count; ++i)
+            {
+                actual[i].Should().Be(values[i]);
+            }
+        }
+    }
+}

--- a/BlueEyes/BlueEyes.csproj
+++ b/BlueEyes/BlueEyes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\build\common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>    
   </PropertyGroup>
 

--- a/BlueEyes/BlueEyes.csproj
+++ b/BlueEyes/BlueEyes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\build\common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>    
   </PropertyGroup>
 

--- a/BlueEyes/Constants.cs
+++ b/BlueEyes/Constants.cs
@@ -13,7 +13,7 @@ namespace BlueEyes
         public const int LeadingZerosLengthBits = 5;
         public const int MaxLeadingZerosLength = (1 << LeadingZerosLengthBits) - 1;
 
-
+        public const int BitsForFirstValue = 64;
         public const int BitsForFirstTimestamp = 31; // Works until 2038.
         public const int DefaultDelta = 60; 
     }

--- a/BlueEyes/ValueReader.cs
+++ b/BlueEyes/ValueReader.cs
@@ -11,16 +11,29 @@ namespace BlueEyes
         private readonly BitBuffer _buffer;
         private long _previousValue;
         private BlockInfo _previousBlockInfo;
+        private bool _hasReadFirstValue;
 
         public ValueReader(BitBuffer buffer)
         {
             _buffer = buffer;
+            _hasReadFirstValue = false;
         }
 
         public bool HasMoreValues => !_buffer.IsAtEndOfBuffer;
         
         public double ReadNextValue()
         {
+            if (_hasReadFirstValue == false)
+            {
+                _previousBlockInfo = BlockInfo.CalulcateBlockInfo(Constants.BitsForFirstValue);
+                var firstValue = (long)_buffer.ReadValue(Constants.BitsForFirstValue);
+
+                _previousValue = firstValue;
+                _hasReadFirstValue = true;
+
+                return BitConverter.Int64BitsToDouble(firstValue);
+            }
+
             var nonZeroValue = _buffer.ReadValue(1);
 
             if (nonZeroValue == 0)

--- a/BlueEyes/ValueWriter.cs
+++ b/BlueEyes/ValueWriter.cs
@@ -11,11 +11,13 @@ namespace BlueEyes
         private readonly BitBuffer _buffer;
         private long _previousValue;
         private BlockInfo _previousBlockInfo;
+        private bool _hasStoredFirstValue;
 
         public ValueWriter(BitBuffer buffer)
         {
             _buffer = buffer;
             _previousBlockInfo = new BlockInfo(0, 0);
+            _hasStoredFirstValue = false;
         }
 
         /// <summary>
@@ -54,7 +56,8 @@ namespace BlueEyes
             var currentBlockInfo = BlockInfo.CalulcateBlockInfo((ulong) xorWithPrevious);
             int expectedSize = Constants.LeadingZerosLengthBits + Constants.BlockSizeLengthBits + currentBlockInfo.BlockSize;
 
-            if (currentBlockInfo.LeadingZeros >= _previousBlockInfo.LeadingZeros &&
+            if (_hasStoredFirstValue &&
+                currentBlockInfo.LeadingZeros >= _previousBlockInfo.LeadingZeros &&
                 currentBlockInfo.TrailingZeros >= _previousBlockInfo.TrailingZeros &&
                 _previousBlockInfo.BlockSize < expectedSize)
             {
@@ -79,6 +82,11 @@ namespace BlueEyes
                 _buffer.AddValue(blockValue, currentBlockInfo.BlockSize);
 
                 _previousBlockInfo = currentBlockInfo;
+                
+                if (!_hasStoredFirstValue)
+                {
+                    _hasStoredFirstValue = true;
+                }
             }
 
             _previousValue = longValue;


### PR DESCRIPTION
This is a proposed fix for issue: #2.
---
Found that some initial values cause corruption of the `BitBuffer`, based on the paper the initial value should not be compressed.

I've added a `_hasStoredFirstValue` condition to the `ValueWriter`, similar to what was present in the `DatetimeWriter`.  I used it to switch to the branch that creates new block information, I'm not 100% sure if this is the best solution.

The text highligted below is from facebook paper: [http://www.vldb.org/pvldb/vol8/p1816-teller.pdf](http://www.vldb.org/pvldb/vol8/p1816-teller.pdf).

![image](https://user-images.githubusercontent.com/10304062/68391603-f27caf80-015f-11ea-9737-c37daec2b20a.png)
