### PR TITLE
First & negative value handling fixes

### DIFF
--- a/BlueEyes.TestApp/BlueEyes.TestApp.csproj
+++ b/BlueEyes.TestApp/BlueEyes.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlueEyes.Tests/BlockInfoTests.cs
+++ b/BlueEyes.Tests/BlockInfoTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Xunit;
 
 namespace BlueEyes.Tests
@@ -13,12 +8,12 @@ namespace BlueEyes.Tests
 
         [Theory]
         [InlineData(0x1FFF_FFFF_FFFF_FFFC, 3, 2)]
-        [InlineData(0x01FF_FFFF_FFFF_FFF8, 7, 3)] 
-        [InlineData(0x8FFF_FFFF_FFFF_FFF1, 0, 0)] 
+        [InlineData(0x01FF_FFFF_FFFF_FFF8, 7, 3)]
+        [InlineData(0x8FFF_FFFF_FFFF_FFF1, 0, 0)]
         [InlineData(0, Constants.MaxLeadingZerosLength, 64)]
         public void CalculateBlockInfoCountsCorrectly(ulong input, int expectedLeadingZeros, int expectedTrailingZeros)
         {
-            var blockInfo = BlockInfo.CalulcateBlockInfo(input);
+            var blockInfo = BlockInfo.CalulcateBlockInfo((long)input);
             blockInfo.LeadingZeros.Should().Be(expectedLeadingZeros);
             blockInfo.TrailingZeros.Should().Be(expectedTrailingZeros);
             blockInfo.BlockSize.Should().Be(64 - expectedLeadingZeros - expectedTrailingZeros);

--- a/BlueEyes.Tests/BlueEyes.Tests.csproj
+++ b/BlueEyes.Tests/BlueEyes.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlueEyes.Tests/ReadWriteTimeseriesTests.cs
+++ b/BlueEyes.Tests/ReadWriteTimeseriesTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace BlueEyes.Tests
@@ -14,6 +15,76 @@ namespace BlueEyes.Tests
             {
                 (new DateTime(2019, 06, 03, 0, 0, 0, DateTimeKind.Utc), 1154.84765552935)
             };
+
+            var timeSeries = new TimeSeries();
+
+            foreach (var (timestamp, value) in values)
+            {
+                timeSeries.AddPoint(timestamp, value);
+            }
+
+            var buffer = timeSeries.ToArray();
+
+            var reader = new TimeSeries(buffer);
+            var actual = new List<(DateTime, double)>();
+
+            while (reader.HasMorePoints)
+            {
+                actual.Add(reader.ReadNext());
+            }
+
+            actual.Count.Should().Be(values.Length);
+
+            for (int i = 0; i < actual.Count; ++i)
+            {
+                actual[i].Should().Be(values[i]);
+            }
+        }
+
+        [Fact]
+        public void WrittenValuesCanBeReadBackCorrectly_Negative()
+        {
+            var values = new (DateTime, double)[]
+            {
+                (new DateTime(2019, 06, 03, 0, 0, 0, DateTimeKind.Utc), 0),
+                (new DateTime(2019, 06, 04, 0, 0, 0, DateTimeKind.Utc), -11),
+                (new DateTime(2019, 06, 05, 0, 0, 0, DateTimeKind.Utc), 11),
+            };
+
+            var timeSeries = new TimeSeries();
+
+            foreach (var (timestamp, value) in values)
+            {
+                timeSeries.AddPoint(timestamp, value);
+            }
+
+            var buffer = timeSeries.ToArray();
+
+            var reader = new TimeSeries(buffer);
+            var actual = new List<(DateTime, double)>();
+
+            while (reader.HasMorePoints)
+            {
+                actual.Add(reader.ReadNext());
+            }
+
+            actual.Count.Should().Be(values.Length);
+
+            for (int i = 0; i < actual.Count; ++i)
+            {
+                actual[i].Should().Be(values[i]);
+            }
+        }
+
+        [Fact]
+        public void WrittenValuesCanBeReadBackCorrectlyWithNegative()
+        {
+            int range = 1000;
+            var values = Enumerable.Range(1, range)
+                .Select(i => (
+                    new DateTime(2018, 05, 01, 00, 0, 0, DateTimeKind.Utc).AddHours(i),
+                    Math.Sin(i)
+                )).ToArray();
 
             var timeSeries = new TimeSeries();
 

--- a/BlueEyes.Tests/ReadWriteTimeseriesTests.cs
+++ b/BlueEyes.Tests/ReadWriteTimeseriesTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace BlueEyes.Tests
+{
+    public class ReadWriteTimeseriesTests
+    {
+        [Fact]
+        public void WrittenValuesCanBeReadBackCorrectly()
+        {
+            var values = new (DateTime, double)[]
+            {
+                (new DateTime(2019, 06, 03, 0, 0, 0, DateTimeKind.Utc), 1154.84765552935)
+            };
+
+            var timeSeries = new TimeSeries();
+
+            foreach (var (timestamp, value) in values)
+            {
+                timeSeries.AddPoint(timestamp, value);
+            }
+
+            var buffer = timeSeries.ToArray();
+
+            var reader = new TimeSeries(buffer);
+            var actual = new List<(DateTime, double)>();
+
+            while (reader.HasMorePoints)
+            {
+                actual.Add(reader.ReadNext());
+            }
+
+            actual.Count.Should().Be(values.Length);
+
+            for (int i = 0; i < actual.Count; ++i)
+            {
+                actual[i].Should().Be(values[i]);
+            }
+        }
+    }
+}

--- a/BlueEyes.Tests/ReadWriteValueTests.cs
+++ b/BlueEyes.Tests/ReadWriteValueTests.cs
@@ -10,12 +10,11 @@ namespace BlueEyes.Tests
 {
     public class ReadWriteValueTests
     {
-
-        [Fact]
-        public void WrittenValuesCanBeReadBackCorrectly()
+        [Theory]
+        [InlineData(new[] { 4, 8, 1.5, 1.6, 1.7, 1.7, 2.3, 22.0 / 7.0, 653.2, 653.02 })]
+        [InlineData(new double[] { 2, -1, 2, 1 })]
+        public void WrittenValuesCanBeReadBackCorrectly(double[] values)
         {
-            var values = new[] {4, 8, 1.5, 1.6, 1.7, 1.7, 2.3, 22.0 / 7.0, 653.2, 653.02};
-            
             var buffer = new BitBuffer();
             var writer = new ValueWriter(buffer);
 
@@ -23,7 +22,6 @@ namespace BlueEyes.Tests
             {
                 writer.AppendValue(value);
             }
-
             
             var reader = new ValueReader(buffer);
 

--- a/BlueEyes/BlockInfo.cs
+++ b/BlueEyes/BlockInfo.cs
@@ -14,8 +14,14 @@ namespace BlueEyes
         public int BlockSize { get; }
 
 
-        public static BlockInfo CalulcateBlockInfo(ulong input)
+        public static BlockInfo CalulcateBlockInfo(long longInput)
         {
+            if (longInput < 0)
+            {
+                return new BlockInfo(0, 0);
+            }
+
+            var input = (ulong)longInput;
             int trailingZeros = 64;
             ulong mask = 1;
             for (int i = 0; i < 64; ++i, mask <<= 1)

--- a/BlueEyes/BlueEyes.csproj
+++ b/BlueEyes/BlueEyes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\build\common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>    
   </PropertyGroup>
 

--- a/BlueEyes/BlueEyes.csproj
+++ b/BlueEyes/BlueEyes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\build\common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>    
   </PropertyGroup>
 

--- a/BlueEyes/Constants.cs
+++ b/BlueEyes/Constants.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BlueEyes
+﻿namespace BlueEyes
 {
     class Constants
     {

--- a/BlueEyes/Constants.cs
+++ b/BlueEyes/Constants.cs
@@ -13,7 +13,7 @@ namespace BlueEyes
         public const int LeadingZerosLengthBits = 5;
         public const int MaxLeadingZerosLength = (1 << LeadingZerosLengthBits) - 1;
 
-
+        public const int BitsForFirstValue = 64;
         public const int BitsForFirstTimestamp = 31; // Works until 2038.
         public const int DefaultDelta = 60; 
     }

--- a/BlueEyes/ValueReader.cs
+++ b/BlueEyes/ValueReader.cs
@@ -11,16 +11,29 @@ namespace BlueEyes
         private readonly BitBuffer _buffer;
         private long _previousValue;
         private BlockInfo _previousBlockInfo;
+        private bool _hasReadFirstValue;
 
         public ValueReader(BitBuffer buffer)
         {
             _buffer = buffer;
+            _hasReadFirstValue = false;
         }
 
         public bool HasMoreValues => !_buffer.IsAtEndOfBuffer;
         
         public double ReadNextValue()
         {
+            if (_hasReadFirstValue == false)
+            {
+                _previousBlockInfo = BlockInfo.CalulcateBlockInfo(Constants.BitsForFirstValue);
+                var firstValue = (long)_buffer.ReadValue(Constants.BitsForFirstValue);
+
+                _previousValue = firstValue;
+                _hasReadFirstValue = true;
+
+                return BitConverter.Int64BitsToDouble(firstValue);
+            }
+
             var nonZeroValue = _buffer.ReadValue(1);
 
             if (nonZeroValue == 0)

--- a/BlueEyes/ValueWriter.cs
+++ b/BlueEyes/ValueWriter.cs
@@ -11,11 +11,13 @@ namespace BlueEyes
         private readonly BitBuffer _buffer;
         private long _previousValue;
         private BlockInfo _previousBlockInfo;
+        private bool _hasStoredFirstValue;
 
         public ValueWriter(BitBuffer buffer)
         {
             _buffer = buffer;
             _previousBlockInfo = new BlockInfo(0, 0);
+            _hasStoredFirstValue = false;
         }
 
         /// <summary>
@@ -54,7 +56,8 @@ namespace BlueEyes
             var currentBlockInfo = BlockInfo.CalulcateBlockInfo((ulong) xorWithPrevious);
             int expectedSize = Constants.LeadingZerosLengthBits + Constants.BlockSizeLengthBits + currentBlockInfo.BlockSize;
 
-            if (currentBlockInfo.LeadingZeros >= _previousBlockInfo.LeadingZeros &&
+            if (_hasStoredFirstValue &&
+                currentBlockInfo.LeadingZeros >= _previousBlockInfo.LeadingZeros &&
                 currentBlockInfo.TrailingZeros >= _previousBlockInfo.TrailingZeros &&
                 _previousBlockInfo.BlockSize < expectedSize)
             {
@@ -79,6 +82,11 @@ namespace BlueEyes
                 _buffer.AddValue(blockValue, currentBlockInfo.BlockSize);
 
                 _previousBlockInfo = currentBlockInfo;
+                
+                if (!_hasStoredFirstValue)
+                {
+                    _hasStoredFirstValue = true;
+                }
             }
 
             _previousValue = longValue;


### PR DESCRIPTION
This PR contains proposed fixes for issues: #2 & #3.
---
Found that some initial values cause corruption of the `BitBuffer`, based on the paper the initial value should not be compressed.

- Added a `_hasStoredFirstValue` condition to the `ValueWriter`, similar to what was present in the `DatetimeWriter`.
- Removed the `expectedLength` condition in the 'ValueWriter' previous/new block check.
- Swapped the control bits to match the value compression logic defined in section 4.1.2 of [this paper](http://www.vldb.org/pvldb/vol8/p1816-teller.pdf).  Should now be compatible with other implementations.
- Bypassed leading/trailing zero calculation for negative diffs.
- Added tests to cover issues found.

The text highligted below is from facebook paper: [http://www.vldb.org/pvldb/vol8/p1816-teller.pdf](http://www.vldb.org/pvldb/vol8/p1816-teller.pdf).

![image](https://user-images.githubusercontent.com/10304062/68391603-f27caf80-015f-11ea-9737-c37daec2b20a.png)
